### PR TITLE
Remove option installing laminas-migration as local dependency

### DIFF
--- a/migration/index.html
+++ b/migration/index.html
@@ -286,26 +286,6 @@ $ cd $HOME/bin && ln -s /path/to/laminas-migration/bin/laminas-migration .
 # creating an alias:
 $ alias laminas-migration=/path/to/laminas-migration/bin/laminas-migration</code></pre>
 
-<h3 id="as-a-local-dependency">As a local dependency</h3>
-
-<p>In this case, require it as you would any other dependency:</p>
-
-<pre class="codehilite"><code class="language-bash">$ composer require --dev laminas/laminas-migration</code></pre>
-
-<p>
-    For purposes of usage, when we refer to the <code>laminas-migration</code> CLI tool, the
-    path will be <code>./vendor/bin/laminas-migration</code>.
-</p>
-
-<blockquote>
-    <p>
-        If you choose this option, make sure you remove the migration tooling
-        when you are done with your migration:
-    </p>
-
-    <pre class="codehilite"><code class="language-bash">$ composer remove --dev laminas/laminas-migration</code></pre>
-</blockquote>
-
 <h2 id="run-the-migration-command">3. Run the migration command</h2>
 
 <p>


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.
Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch
-->

|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | yes

### Description

Because migration removes vendor direcotry local installation of
laminas-migration is not working properly.

Global installation or cloning should be used instead.

See: 
- https://github.com/laminas/laminas-migration/issues/35
- https://github.com/laminas/laminas-migration/issues/38

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->
